### PR TITLE
Fix gettid() naming conflict

### DIFF
--- a/src/core/lib/support/log_linux.c
+++ b/src/core/lib/support/log_linux.c
@@ -39,7 +39,9 @@
 #include <time.h>
 #include <unistd.h>
 
-static long gettid(void) { return syscall(__NR_gettid); }
+// Not naming it as gettid() to avoid duplicate declarations when complied with
+// GCC 9.1.
+static long local_gettid(void) { return syscall(__NR_gettid); }
 
 void gpr_log(const char *file, int line, gpr_log_severity severity,
              const char *format, ...) {
@@ -65,7 +67,7 @@ void gpr_default_log(gpr_log_func_args *args) {
   gpr_timespec now = gpr_now(GPR_CLOCK_REALTIME);
   struct tm tm;
   static __thread long tid = 0;
-  if (tid == 0) tid = gettid();
+  if (tid == 0) tid = local_gettid();
 
   timer = (time_t)now.tv_sec;
   final_slash = strrchr(args->file, '/');


### PR DESCRIPTION
This is a cherry-pick of https://github.com/grpc/grpc/pull/20048 that applied cleanly.

Work towards https://github.com/pantsbuild/pants/issues/8472